### PR TITLE
Avoid exception there is no active transaction

### DIFF
--- a/src/Driver/TransactionalConnection.php
+++ b/src/Driver/TransactionalConnection.php
@@ -8,4 +8,5 @@ interface TransactionalConnection
     public function beginTransaction(): void;
     public function commit(): void;
     public function rollBack(): void;
+    public function isTransactionActive(): bool;
 }

--- a/src/SymfonyMessenger/TransactionMiddleware.php
+++ b/src/SymfonyMessenger/TransactionMiddleware.php
@@ -31,6 +31,10 @@ final class TransactionMiddleware implements MiddlewareInterface
 
             return $envelope;
         } catch (\Throwable $exception) {
+            if ($this->connection->isTransactionActive()) {
+                $this->connection->rollBack();
+            }
+
             $this->connection->rollBack();
 
             throw $exception;


### PR DESCRIPTION
Rollback only when transaction is active. To avoid There is no active transaction exception