### PR TITLE
XDebug updated. Rollback only when connection is open

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add --no-cache \
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer
 
 RUN apk add --no-cache --virtual .phpize_deps $PHPIZE_DEPS && \
-    pecl install xdebug-2.9.2 && \
+    pecl install xdebug-3.1.3 && \
     docker-php-ext-enable xdebug && \
     rm -rf /usr/share/php7 && \
     rm -rf /tmp/pear && \

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,12 @@
   },
   "require-dev": {
     "pccomponentes/coding-standard": "^1.0",
-    "phpunit/phpunit": "^8.5",
+    "phpunit/phpunit": "^9",
     "dg/bypass-finals": "^1.1"
+  },
+  "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   }
 }

--- a/src/SymfonyMessenger/TransactionMiddleware.php
+++ b/src/SymfonyMessenger/TransactionMiddleware.php
@@ -35,8 +35,6 @@ final class TransactionMiddleware implements MiddlewareInterface
                 $this->connection->rollBack();
             }
 
-            $this->connection->rollBack();
-
             throw $exception;
         }
     }

--- a/tests/SymfonyMessenger/TransactionMiddlewareTest.php
+++ b/tests/SymfonyMessenger/TransactionMiddlewareTest.php
@@ -69,7 +69,7 @@ final class TransactionMiddlewareTest extends TestCase
     /**
      * @test
      */
-    public function given_next_middleware_throwing_exception_when_handle_then_rollback_transaction_and_throw_catch_exception()
+    public function given_next_middleware_throwing_exception_when_handle_and_connection_is_open_then_rollback_transaction_and_throw_catch_exception()
     {
         $transactionalConnection = $this->createMock(TransactionalConnection::class);
         $nextMiddleware = $this->createMock(MiddlewareInterface::class);
@@ -94,6 +94,12 @@ final class TransactionMiddlewareTest extends TestCase
             ->expects($this->never())
             ->method('commit')
         ;
+
+        $transactionalConnection
+            ->expects($this->once())
+            ->method('isTransactionActive')
+            ->willReturn(true);
+
         $transactionalConnection
             ->expects($this->once())
             ->method('rollback')


### PR DESCRIPTION
- XDebug updated to new PHP Version
- Rollback only when transaction is already open.
- Tests addapted